### PR TITLE
Adds Bun support to Astro workflow

### DIFF
--- a/.github/workflows/astro.yml
+++ b/.github/workflows/astro.yml
@@ -38,7 +38,13 @@ jobs:
       - name: Detect package manager
         id: detect-package-manager
         run: |
-          if [ -f "${{ github.workspace }}/yarn.lock" ]; then
+          if [ -f "${{ github.workspace }}/bun.lock" ]; then
+            echo "manager=bun" >> $GITHUB_OUTPUT
+            echo "command=install --frozen-lockfile" >> $GITHUB_OUTPUT
+            echo "runner=bun" >> $GITHUB_OUTPUT
+            echo "lockfile=bun.lock" >> $GITHUB_OUTPUT
+            exit 0
+          elif [ -f "${{ github.workspace }}/yarn.lock" ]; then
             echo "manager=yarn" >> $GITHUB_OUTPUT
             echo "command=install" >> $GITHUB_OUTPUT
             echo "runner=yarn" >> $GITHUB_OUTPUT
@@ -54,7 +60,13 @@ jobs:
             echo "Unable to determine package manager"
             exit 1
           fi
+      - name: Setup Bun
+        if: steps.detect-package-manager.outputs.manager == 'bun'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       - name: Setup Node
+        if: steps.detect-package-manager.outputs.manager != 'bun'
         uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
Detects Bun as a package manager and configures the environment accordingly when a lockfile is present. This ensures compatibility for projects using Bun by providing the necessary setup and execution commands.