### PR TITLE
refactor: add aria-labels to member links and alt for image logo

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -26,7 +26,7 @@ import IconArrowUpRight from "~icons/tabler/arrow-up-right";
     >
     </div>
     <a href="/" class="items-center text-lg font-semibold sm:flex hidden">
-      <img class="size-10" src={logo.src} /> Laravel Indonesia
+      <img class="size-10" src={logo.src} alt="Lara Army Logo" /> Laravel Indonesia
     </a>
     <div class="flex items-center gap-1">
       <a class="hover:underline text-sm text-foreground-body" href="#acara"

--- a/src/components/member-card.astro
+++ b/src/components/member-card.astro
@@ -22,8 +22,8 @@ const { data } = Astro.props;
   </div>
   <div class="flex gap-2 ml-auto pr-4">
     {
-      data.links.map(({ Icon, url }) => (
-        <a href={url} target="_blank" rel="noopener noreferrer">
+      data.links.map(({ Icon, url, label }) => (
+        <a href={url} target="_blank" rel="noopener noreferrer" aria-label={label}>
           <Icon />
         </a>
       ))

--- a/src/constants/honorable-members.ts
+++ b/src/constants/honorable-members.ts
@@ -9,6 +9,7 @@ export interface HonorableMember {
   links: {
     Icon: JSX.Element,
     url: string,
+    label: string,
   }[]
 
 }
@@ -22,9 +23,11 @@ const honorableMembers: HonorableMember[] = [
       {
         Icon: IconBrandGithub,
         url: 'https://github.com/dominosaurs',
+        label: "dominos' GitHub",
       }, {
         Icon: IconBrandX,
         url: 'https://x.com/dominosaurs_',
+        label: "dominos' X",
       }
     ]
   }, {
@@ -32,12 +35,14 @@ const honorableMembers: HonorableMember[] = [
     avatarSrc: 'https://github.com/kimmyxpow.png',
     title: 'Insinyur Desain',
     links: [
-      {
+       {
         Icon: IconBrandGithub,
         url: 'http://github.com/kimmyxpow',
+        label: "pow's GitHub",
       }, {
         Icon: IconBrandX,
         url: 'https://x.com/kimmyxpow',
+        label: "pow's X",
       }
     ]
   }


### PR DESCRIPTION
### Fix Accessibility issues

<img width="1432" height="639" alt="image" src="https://github.com/user-attachments/assets/a6bad6b2-ea9b-4245-a50e-fe0a2cdf8720" />
