### PR TITLE
ci: add CODEOWNERS file to define default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @kimmyxpow @dominosaurs


### PR DESCRIPTION
Define @kimmyxpow and @dominosaurs as default code owners for all files in the repository to streamline the review assignment process.